### PR TITLE
Correct tag handling during identifier selection

### DIFF
--- a/docker_registry_client_async/dockerregistryclientasync.py
+++ b/docker_registry_client_async/dockerregistryclientasync.py
@@ -747,6 +747,32 @@ class DockerRegistryClientAsync:
         client_session = await self._get_client_session()
         return await client_session.get(headers=headers, url=url, **kwargs)
 
+    async def get_tag_list(
+        self, image_name: ImageName, **kwargs
+    ) -> DockerRegistryClientAsyncGetTags:
+        """
+        Fetch the tags under the repository identified by name.
+
+        Args:
+            image_name: The image name.
+        Keyword Args:
+            protocol: Protocol to use when connecting to the endpoint.
+
+        Returns:
+            dict:
+                client_response: The underlying client response.
+                tags: The corresponding list of image tags.
+        """
+        client_response = await self._get_tags(
+            image_name, raise_for_status=True, **kwargs
+        )
+        tags = await client_response.json()
+        tags = [
+            ImageName(image_name.image, endpoint=image_name.endpoint, tag=tag)
+            for tag in tags["tags"]
+        ]
+        return {"client_response": client_response, "tags": tags}
+
     async def get_tags(
         self, image_name: ImageName, **kwargs
     ) -> DockerRegistryClientAsyncGetTags:

--- a/docker_registry_client_async/dockerregistryclientasync.py
+++ b/docker_registry_client_async/dockerregistryclientasync.py
@@ -646,10 +646,9 @@ class DockerRegistryClientAsync:
         Returns:
             The underlying client response.
         """
-        identifier = ""
         if image_name.digest:
             identifier = image_name.resolve_digest()
-        elif image_name.tag:
+        else:
             identifier = image_name.resolve_tag()
         if accept is None:
             accept = (
@@ -887,10 +886,9 @@ class DockerRegistryClientAsync:
         Returns:
             The underlying client response.
         """
-        identifier = ""
         if image_name.digest:
             identifier = image_name.resolve_digest()
-        elif image_name.tag:
+        else:
             identifier = image_name.resolve_tag()
         protocol = kwargs.pop("protocol", DockerRegistryClientAsync.DEFAULT_PROTOCOL)
 
@@ -1271,10 +1269,9 @@ class DockerRegistryClientAsync:
         Returns:
             The underlying client response.
         """
-        identifier = ""
         if image_name.digest:
             identifier = image_name.resolve_digest()
-        elif image_name.tag:
+        else:
             identifier = image_name.resolve_tag()
         protocol = kwargs.pop("protocol", DockerRegistryClientAsync.DEFAULT_PROTOCOL)
 

--- a/tests/test_dockerregistryclientasync.py
+++ b/tests/test_dockerregistryclientasync.py
@@ -955,6 +955,19 @@ async def test_get_manifest(
 
 
 @pytest.mark.online
+async def test_get_manifest_sanity_check():
+    """Test that 'python' works against index.docker.io."""
+    # Note: Using default credentials store from the test environment
+    async with DockerRegistryClientAsync() as docker_registry_client_async:
+        image_name = ImageName.parse("python")
+        media_type = DockerMediaTypes.DISTRIBUTION_MANIFEST_V2
+        LOGGER.debug("Retrieving manifest for: %s (%s) ...", image_name, media_type)
+        response = await docker_registry_client_async.get_manifest(image_name, accept=media_type)
+        assert all(x in response for x in ["client_response", "manifest"])
+        assert response["manifest"]
+
+
+@pytest.mark.online
 async def test_get_manifest_to_disk_async(
     docker_registry_client_async: DockerRegistryClientAsync,
     known_good_image,

--- a/tests/test_dockerregistryclientasync.py
+++ b/tests/test_dockerregistryclientasync.py
@@ -962,7 +962,9 @@ async def test_get_manifest_sanity_check():
         image_name = ImageName.parse("python")
         media_type = DockerMediaTypes.DISTRIBUTION_MANIFEST_V2
         LOGGER.debug("Retrieving manifest for: %s (%s) ...", image_name, media_type)
-        response = await docker_registry_client_async.get_manifest(image_name, accept=media_type)
+        response = await docker_registry_client_async.get_manifest(
+            image_name, accept=media_type
+        )
         assert all(x in response for x in ["client_response", "manifest"])
         assert response["manifest"]
 
@@ -1036,6 +1038,26 @@ async def test__get_tags(
     assert tags["name"] == image_name.resolve_image()
     assert "tags" in tags
     assert image_name.resolve_tag() in tags["tags"]
+
+
+@pytest.mark.online
+async def test_get_tag_list(
+    docker_registry_client_async: DockerRegistryClientAsync, known_good_image
+):
+    """Test that the image tags can be retrieved."""
+    image_name = ImageName.parse(
+        f"{known_good_image['image']}:{known_good_image['tag']}"
+    )
+    LOGGER.debug("Retrieving tag list for: %s ...", image_name)
+    response = await docker_registry_client_async.get_tag_list(image_name)
+    assert all(x in response for x in ["client_response", "tags"])
+
+    result = False
+    for entry in response["tags"]:
+        if entry.resolve_tag() == image_name.resolve_tag():
+            result = True
+            break
+    assert result
 
 
 @pytest.mark.online


### PR DESCRIPTION
A user-identified gap in testing resulted in a regression during identifier selection. This prevented tag defaulting during name resolution, and subsequently produced malformed requests.