### PR TITLE
Add asynchronous library sanity check tests.

### DIFF
--- a/tests/test_aiolibs.py
+++ b/tests/test_aiolibs.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+"""Asynchronous library tests."""
+
+import logging
+
+from socket import AF_INET
+
+import pytest
+
+from aiodns import DNSResolver
+from aiodns.error import DNSError
+from aiohttp import AsyncResolver
+from pycares import ares_host_result
+
+pytestmark = [pytest.mark.asyncio]
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "domain,name_unqualified",
+    [("google.com", "calendar"), ("microsoft.com", "answers")],
+)
+async def test_aiodns_domain_search_list(
+    domain: str, event_loop, name_unqualified: str
+):
+    """Test that the domain search list is functioning."""
+    dns_resolver = DNSResolver(loop=event_loop)
+    name_qualified = f"{name_unqualified}.{domain}"
+
+    # Fully Qualified
+    response = await dns_resolver.gethostbyname(
+        name_qualified, AF_INET
+    )  # type: ares_host_result
+    LOGGER.debug("Qualified resolution: %s", response)
+    assert response.name
+    assert (response.name == name_qualified) or (name_qualified in response.aliases)
+    assert len(response.addresses)
+
+    # Unqualified w/o domain search list
+    with pytest.raises(DNSError) as exception:
+        await dns_resolver.gethostbyname(name_unqualified, AF_INET)
+    assert "Domain name not found" in str(exception.value)
+
+    dns_resolver = DNSResolver(domains=[domain], loop=event_loop)
+
+    # Unqualified w/ domain search list
+    response = await dns_resolver.gethostbyname(
+        name_unqualified, AF_INET
+    )  # type: ares_host_result
+    LOGGER.debug("Unqualified resolution: %s", response)
+    assert response.name
+    assert (response.name == name_qualified) or next(
+        alias for alias in response.aliases if alias.startswith(f"{name_unqualified}.")
+    )
+    assert len(response.addresses)
+
+
+@pytest.mark.parametrize(
+    "domain,name_unqualified",
+    [("google.com", "calendar"), ("microsoft.com", "answers")],
+)
+async def test_aiohttp_domain_search_list(
+    domain: str, event_loop, name_unqualified: str
+):
+    """Test that the domain search list is functioning."""
+    async_resolver = AsyncResolver(loop=event_loop)
+    name_qualified = f"{name_unqualified}.{domain}"
+
+    # Fully Qualified
+    response = await async_resolver.resolve(name_qualified, family=AF_INET)
+    LOGGER.debug("Qualified resolution: %s", response)
+    assert len(response)
+    assert response[0]["hostname"] == name_qualified
+    assert response[0]["host"]
+
+    # Unqualified w/o domain search list
+    with pytest.raises(OSError) as exception:
+        await async_resolver.resolve(name_unqualified, family=AF_INET)
+    assert "Domain name not found" in str(exception.value)
+
+    async_resolver = AsyncResolver(domains=[domain], loop=event_loop)
+
+    # Unqualified w/ domain search list
+    response = await async_resolver.resolve(name_unqualified, family=AF_INET)
+    LOGGER.debug("Unqualified resolution: %s", response)
+    assert len(response)
+    assert response[0]["hostname"] == name_unqualified
+    assert response[0]["host"]


### PR DESCRIPTION
```bash
tests/test_aiolibs.py::test_aiodns_domain_search_list
------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
DEBUG    asyncio:selector_events.py:59 Using selector: EpollSelector
-------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------
DEBUG    tests.test_aiolibs:test_aiolibs.py:28 Qualified resolution: <ares_host_result> name=e763.b.akamaiedge.net, aliases=['answers.microsoft.com', 'answers.microsoft.com.edgekey.net'], addresses=['23.51.162.229']
DEBUG    tests.test_aiolibs:test_aiolibs.py:44 Unqualified resolution: <ares_host_result> name=e763.b.akamaiedge.net, aliases=['answers.microsoft.com', 'answers.microsoft.com.edgekey.net'], addresses=['23.51.162.229']
PASSED                                                                                                                                                                                                      [ 50%]
tests/test_aiolibs.py::test_aiohttp_domain_search_list
------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
DEBUG    asyncio:selector_events.py:59 Using selector: EpollSelector
-------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------
DEBUG    tests.test_aiolibs:test_aiolibs.py:57 Qualified resolution: [{'hostname': 'answers.microsoft.com', 'host': '23.51.162.229', 'port': 0, 'family': <AddressFamily.AF_INET: 2>, 'proto': 0, 'flags': <AddressInfo.AI_NUMERICSERV|AI_NUMERICHOST: 1028>}]
DEBUG    tests.test_aiolibs:test_aiolibs.py:73 Unqualified resolution: [{'hostname': 'answers', 'host': '23.51.162.229', 'port': 0, 'family': <AddressFamily.AF_INET: 2>, 'proto': 0, 'flags': <AddressInfo.AI_NUMERICSERV|AI_NUMERICHOST: 1028>}]
PASSED                                                                                                                                                                                                      [100%]

================================================================================================ 2 passed in 0.09s ================================================================================================
```