### PR TITLE
adding minimum python constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "test": ["pytest-xdist"],
     },
     include_package_data=True,
+    python_requires=">=3.8",
     install_requires=[
         "aiodns",
         "aiofiles",


### PR DESCRIPTION
It is currently possible to install this package on py36. But when used the below will show.

```shell
>   from typing import Any, TypedDict, Union
E   ImportError: cannot import name 'TypedDict'

.../lib/python3.6/site-packages/docker_registry_client_async/typing.py:7: ImportError
```

Because `TypedDict` is py38+ I would suggest limiting installation to py38 and above.