### PR TITLE
Add py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "test": ["pytest-xdist"],
     },
     include_package_data=True,
+    package_data={'docker_registry_client_async': ['py.typed']},
     python_requires=">=3.8",
     install_requires=[
         "aiodns",


### PR DESCRIPTION
This enables static type checking of consumer applications by using drca's inline type annotations.