### PR TITLE
Fix compatibility with ACR

### DIFF
--- a/docker_registry_client_async/dockerregistryclientasync.py
+++ b/docker_registry_client_async/dockerregistryclientasync.py
@@ -292,7 +292,9 @@ class DockerRegistryClientAsync:
         if json_kwargs is None:
             json_kwargs = {}
         payload = await client_response.json(**json_kwargs)
-        return payload.get("token", None)
+        if "token" in payload:
+            return payload["token"]
+        return payload.get("access_token", None)
 
     async def _get_client_session(self) -> ClientSession:
         """


### PR DESCRIPTION
Registries such as the Azure Container Registry don't follow the [spec](https://distribution.github.io/distribution/spec/auth/token/) when making a request to `https://acrname.azurecr.io/oauth2/token`.

The returned JSON lacks a "token" (but only contains "access_token" and "refresh_token").

This PR extracts the `access_token` from the payload, if the `token` is missing.